### PR TITLE
Mirror `gcr.io` image to Github

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,8 +6,9 @@ parameters:
 
     images:
       eventrouter:
-        registry: "gcr.io"
-        image: "heptio-images/eventrouter"
+        # Image mirrored from gcr.io/heptio-images/eventrouter:v0.3 as Heptio is long gone and gcr.io to be shut down in March 2025.
+        registry: "ghcr.io"
+        image: "projectsyn/component-eventrouter"
         tag: v0.3
 
     resources:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,6 +11,27 @@ default:: `syn-eventrouter`
 The namespace in which to deploy this component.
 
 
+== `image`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+eventrouter:
+  registry: "ghcr.io"
+  image: "projectsyn/component-eventrouter"
+  tag: v0.3
+----
+
+The images to use for the eventrouter pods.
+
+[IMPORTANT]
+====
+The `eventrouter` image is mirrored from the upstream image `gcr.io/heptio-images/eventrouter:v0.3` as Heptio is long gone and the Google Container Registry (gcr) is to be shut down in March 2025.
+====
+
 == `resources`
 
 [horizontal]

--- a/tests/golden/defaults/eventrouter/eventrouter/10_eventrouter.yaml
+++ b/tests/golden/defaults/eventrouter/eventrouter/10_eventrouter.yaml
@@ -83,7 +83,7 @@ spec:
       containers:
         - args: []
           env: []
-          image: gcr.io/heptio-images/eventrouter:v0.3
+          image: ghcr.io/projectsyn/component-eventrouter:v0.3
           imagePullPolicy: IfNotPresent
           name: kube-eventrouter
           ports: []


### PR DESCRIPTION
`gcr.io` is deprecated and will be shut down https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown.

Image mirrored with crane:

```
❯ crane copy gcr.io/heptio-images/eventrouter:v0.3 ghcr.io/projectsyn/component-eventrouter:v0.3
2025/01/20 15:16:03 Copying from gcr.io/heptio-images/eventrouter:v0.3 to ghcr.io/projectsyn/component-eventrouter:v0.3
2025/01/20 15:16:17 ghcr.io/projectsyn/component-eventrouter:v0.3: digest: sha256:dba60a88600d2d94fcd4c365e2931e54ae9aa495e94a924f80814e019b7ea046 size: 1157
```

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
